### PR TITLE
Update pluto_model.yaml

### DIFF
--- a/config/model/pluto_model.yaml
+++ b/config/model/pluto_model.yaml
@@ -16,7 +16,7 @@ num_modes: 12
 state_dropout: 0.75
 use_ego_history: false
 state_attn_encoder: true
-use_hidden_proj: false
+use_hidden_proj: true
 cat_x: true
 ref_free_traj: true
 

--- a/config/model/pluto_model.yaml
+++ b/config/model/pluto_model.yaml
@@ -17,6 +17,8 @@ state_dropout: 0.75
 use_ego_history: false
 state_attn_encoder: true
 use_hidden_proj: false
+cat_x: true
+ref_free_traj: true
 
 feature_builder:
   _target_: src.feature_builders.pluto_feature_builder.PlutoFeatureBuilder


### PR DESCRIPTION
Set `cat_x` and `ref_free_traj` to true to avoid mismatch between pluto_model.yaml and pluto_planner.yaml, which will cause loading locally trained weights fails during simulation as mentioned in https://github.com/jchengai/pluto/issues/12.

Specifically, the pluto_model.yaml does not set `cat_x` and `ref_free_traj`, which will use default setting defined in pluto_model.py, which are both false. However, the pluto_planner.yaml requires `cat_x` and `ref_free_traj` to be true, which also works with provided weights.

Another way is to modify the default value to true in model definition, I am not sure which one is better, maybe you can help : )